### PR TITLE
Fix comparison of Long, compatible with new raw event lists

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.nb.ads</groupId>
   <artifactId>ads-hive-udfs</artifactId>
   <name>Ads Hive UDF</name>
-  <version>1.0.0</version>
+  <version>1.0.2</version>
   <url>http://maven.apache.org</url>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <packaging>jar</packaging>
   <groupId>com.nb.ads</groupId>
   <artifactId>ads-hive-udfs</artifactId>

--- a/src/main/java/com/nb/ads/api/feature/CommonFeatureUtils.java
+++ b/src/main/java/com/nb/ads/api/feature/CommonFeatureUtils.java
@@ -103,7 +103,8 @@ public class CommonFeatureUtils {
             // some part is missing
             break;
           }
-          if (eventInfo.get(i) != adInfo.get(i)) {
+          Long id = eventInfo.get(i);
+          if (id == null || !id.equals(adInfo.get(i))) {
             // try to match the upper level
             continue;
           }
@@ -168,8 +169,17 @@ public class CommonFeatureUtils {
       if (ele == null) {
         continue;
       }
+      String list = ele.getAsString();
+      if (list.startsWith("[\"")) {
+        // pattern
+        int length = list.length();
+        if (length < 4) {
+          continue;
+        }
+        list = list.substring(2, length - 2);
+      }
       try {
-        Long[][] arrays = gson.fromJson(ele.getAsString(), Long[][].class);
+        Long[][] arrays = gson.fromJson(list, Long[][].class);
         userEventList.put(
             userEventName.getValue(),
             Arrays.stream(arrays).map(Arrays::asList).collect(Collectors.toList()));


### PR DESCRIPTION
1. use Long.equals instead of operator== because the latter compares the reference not the value
2. raw event list is a "list" of string now. trim the begin and end to make it work